### PR TITLE
Solved issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 
     </div>
     <div class="top-section">
-      <button onclick="toggle()">
+      <button onclick="toggle()" id = "sun-btn">
         <img src="img/sun.png" id="toggle"></img>
       </button>
 

--- a/style.css
+++ b/style.css
@@ -42,6 +42,15 @@ body {
   text-align: center;
   /* justify-content: center; */
 }
+#sun-btn{
+  background: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+	outline: inherit;
+}
 #toggle {
   position: absolute;
   top: 10px;


### PR DESCRIPTION
Light Dark button is overflowing on top left of page. Removed the overflowing button and now can only switch light and dark mode from sun and moon image.
<img width="738" alt="Screenshot 2022-10-22 at 4 00 30 PM" src="https://user-images.githubusercontent.com/85477522/197334440-44206db7-b8c9-4703-8f99-0c596098baad.png">
